### PR TITLE
Bugfix: Naming cookies on Firebase CDN

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,0 +1,2 @@
+/** @type {string} */
+export const COOKIE_NAME = "__session"

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -1,12 +1,13 @@
 import { error, redirect } from "@sveltejs/kit"
 import { admin } from "$lib/admin.server"
+import { COOKIE_NAME } from "$lib/constants"
 
 /** @type {import('@sveltejs/kit').Actions} */
 export const actions = {
   create: async (event) => {
     const formData = await event.request.formData()
     const auctionSize = validateAuctionSize(formData.get("auction-size"))
-    const uid = event.cookies.get("firebaseuid")
+    const uid = event.cookies.get(COOKIE_NAME)
     const pin = await getNextPin()
     await setupAuctionAndBidder(auctionSize, uid, pin)
     throw redirect(303, `/${pin}/1`)
@@ -14,7 +15,7 @@ export const actions = {
   join: async (event) => {
     const formData = await event.request.formData()
     const pin = parseInt(formData.get("pin"))
-    const uid = event.cookies.get("firebaseuid")
+    const uid = event.cookies.get(COOKIE_NAME)
     await enrollBidderInAuction(uid, pin)
     throw redirect(303, `/${pin}/1`)
   },

--- a/src/routes/[pin]/+layout.server.js
+++ b/src/routes/[pin]/+layout.server.js
@@ -1,8 +1,9 @@
 import { admin } from "$lib/admin.server"
+import { COOKIE_NAME } from "$lib/constants"
 
 /** @type {import('./$types').LayoutServerLoad} */
 export async function load({ params, cookies }) {
-  const uid = cookies.get("firebaseuid")
+  const uid = cookies.get(COOKIE_NAME)
   const auctionRef = admin.database().ref(`auctions/${params.pin}`)
   const seat = await auctionRef
     .child(`seats/${uid}`)

--- a/src/routes/[pin]/[round]/+page.server.js
+++ b/src/routes/[pin]/[round]/+page.server.js
@@ -1,11 +1,12 @@
 import { admin } from "$lib/admin.server"
+import { COOKIE_NAME } from "$lib/constants"
 
 /** @type {import('@sveltejs/kit').Actions} */
 export const actions = {
   submit: async (event) => {
     const formData = await event.request.formData()
     const bids = JSON.parse(formData.get("bids"))
-    const uid = event.cookies.get("firebaseuid")
+    const uid = event.cookies.get(COOKIE_NAME)
     const round = parseInt(event.params.round)
     const pin = parseInt(event.params.pin)
     await admin.database().ref(`auctions/${pin}/bids/${uid}`).set(bids)

--- a/src/routes/api/cookie/+server.js
+++ b/src/routes/api/cookie/+server.js
@@ -1,11 +1,12 @@
 import { validateUserAndGetUid } from "$lib/admin.server"
 import { json } from "@sveltejs/kit"
+import { COOKIE_NAME } from "$lib/constants"
 
 /** @type {import('@sveltejs/kit').RequestHandler} */
 export async function POST(event) {
   const requestBody = await event.request.json()
   const uid = await validateUserAndGetUid(requestBody.useridtoken)
-  event.cookies.set("firebaseuid", uid, {
+  event.cookies.set(COOKIE_NAME, uid, {
     path: "/",
     maxAge: 60 * 60 * 24 * 2, // say, 2 days
   })


### PR DESCRIPTION
Previously the cookie was never read properly on first page load in a auction. 
This meant that you couldn't tell which bidder/color you were. 

This was a problem only in production. 

According to https://firebase.google.com/docs/hosting/manage-cache the only cookie that is loaded correctly on CDN is `__session`. 
This PR renames the cookie accordingly.