### PR TITLE
Get slugs from $app/stores

### DIFF
--- a/src/routes/[pin=int]/+layout.server.js
+++ b/src/routes/[pin=int]/+layout.server.js
@@ -34,7 +34,6 @@ export async function load({ params, cookies }) {
   colors.length = size
   return {
     size: size,
-    pin: params.pin,
     colors: colors,
     seat: seat,
   }

--- a/src/routes/[pin=int]/+layout.svelte
+++ b/src/routes/[pin=int]/+layout.svelte
@@ -3,14 +3,12 @@
   import { getDatabase, onValue, ref } from "firebase/database"
   import Firebase from "$lib/Firebase.svelte"
   import { onMount } from "svelte"
-
-  /** @type {import('./$types').LayoutData} */
-  export let data
+  import { page } from "$app/stores"
 
   onMount(() => {
     const roundRef = ref(
       getDatabase($firebaseApp),
-      `auctions/${data.pin}/round`
+      `auctions/${$page.params.pin}/round`
     )
     onValue(roundRef, (snap) => {
       currentRound.set(snap.val())

--- a/src/routes/[pin=int]/[round=int]/+layout.server.js
+++ b/src/routes/[pin=int]/[round=int]/+layout.server.js
@@ -13,6 +13,5 @@ export async function load({ params }) {
   }
   return {
     scores: scoreboard,
-    round: params?.round,
   }
 }

--- a/src/routes/[pin=int]/[round=int]/+layout.svelte
+++ b/src/routes/[pin=int]/[round=int]/+layout.svelte
@@ -1,5 +1,6 @@
 <script>
   import ScoreItem from "./ScoreItem.svelte"
+  import { page } from "$app/stores"
   /** @type {import('./$types').LayoutData} */
   export let data
 </script>
@@ -11,7 +12,7 @@
     {#each data.colors as color, i}
       <ScoreItem
         {color}
-        opener={i + 1 == data.round % data.size}
+        opener={i + 1 == $page.params.round % data.size}
         you={i == data.seat}
         score={data.scores[i]}
       />

--- a/src/routes/[pin=int]/[round=int]/+page.svelte
+++ b/src/routes/[pin=int]/[round=int]/+page.svelte
@@ -1,9 +1,8 @@
 <script>
   import { currentRound } from "$lib/stores"
   import { enhance } from "$app/forms"
+  import { page } from "$app/stores"
 
-  /** @type {import('./$types').PageData} */
-  export let data
   export let form
 
   let bids = {
@@ -24,13 +23,13 @@
     15: null,
   }
 
-  const round = parseInt(data.round)
+  const round = parseInt($page.params.round)
 
   function previousRoundResultsAddress() {
-    return `/${data.pin}/${round - 1}/results`
+    return `/${$page.params.pin}/${round - 1}/results`
   }
   function currentRoundResultsAddress() {
-    return `/${data.pin}/${$currentRound - 1}/results`
+    return `/${$page.params.pin}/${$currentRound - 1}/results`
   }
 </script>
 

--- a/src/routes/[pin=int]/[round=int]/results/+page.svelte
+++ b/src/routes/[pin=int]/[round=int]/results/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { page } from "$app/stores"
   /** @type {import('./$types').PageData} */
   export let data
 
@@ -9,8 +10,8 @@
   }
 
   function nextRoundBiddingAddress() {
-    const nextRound = parseInt(data.round) + 1
-    return `/${data.pin}/${nextRound}`
+    const nextRound = parseInt($page.params.round) + 1
+    return `/${$page.params.pin}/${nextRound}`
   }
 </script>
 


### PR DESCRIPTION
Previously slugs were handed from server-side through data-objects to client-side. That was cumbersome compared to pulling slugs from the page-store