### PR TITLE
Add buttons for bidding

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,8 +1,4 @@
 /** @type {string} */
 export const COOKIE_NAME = "__session"
 /** @type {string} */
-export const INPUT_BY_BUTTONS = "buttons"
-/** @type {string} */
-export const INPUT_BY_KEYBOARD = "keyboard"
-/** @type {string} */
 export const LOADING = "loading"

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,2 +1,6 @@
 /** @type {string} */
 export const COOKIE_NAME = "__session"
+/** @type {string} */
+export const INPUT_BY_BUTTONS = "buttons"
+/** @type {string} */
+export const INPUT_BY_KEYBOARD = "keyboard"

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -4,3 +4,5 @@ export const COOKIE_NAME = "__session"
 export const INPUT_BY_BUTTONS = "buttons"
 /** @type {string} */
 export const INPUT_BY_KEYBOARD = "keyboard"
+/** @type {string} */
+export const LOADING = "loading"

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -1,5 +1,4 @@
 import { derived, writable } from "svelte/store"
-import { INPUT_BY_KEYBOARD } from "./constants"
 import { page } from "$app/stores"
 
 /** @type {import("svelte/store").Writable<string>} */
@@ -12,5 +11,5 @@ export const currentRound = writable(0)
 export const pin = derived(page, ($page) => $page.params.pin)
 /** @type {import("svelte/store").Writable<number>} */
 export const round = derived(page, ($page) => $page.params.round)
-/** @type {import("svelte/store").Writable<string>} */
-export const inputMethod = writable(INPUT_BY_KEYBOARD)
+/** @type {import("svelte/store").Writable<boolean>} */
+export const bidByButtons = writable(false)

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -1,10 +1,8 @@
-import { derived, writable } from "svelte/store"
+import { writable } from "svelte/store"
 
 /** @type {import("svelte/store").Writable<string>} */
 export const uid = writable(null)
 /** @type {import("svelte/store").Writable<import("@firebase/app").FirebaseApp>} */
 export const firebaseApp = writable(null)
-export const auctionSize = writable(0)
-export const seat = writable(0)
 /** @type {import("svelte/store").Writable<number>} */
 export const currentRound = writable(0)

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -1,4 +1,5 @@
 import { writable } from "svelte/store"
+import { INPUT_BY_KEYBOARD } from "./constants"
 
 /** @type {import("svelte/store").Writable<string>} */
 export const uid = writable(null)
@@ -6,3 +7,5 @@ export const uid = writable(null)
 export const firebaseApp = writable(null)
 /** @type {import("svelte/store").Writable<number>} */
 export const currentRound = writable(0)
+/** @type {import("svelte/store").Writable<string>} */
+export const inputMethod = writable(INPUT_BY_KEYBOARD)

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -1,5 +1,6 @@
-import { writable } from "svelte/store"
+import { derived, writable } from "svelte/store"
 import { INPUT_BY_KEYBOARD } from "./constants"
+import { page } from "$app/stores"
 
 /** @type {import("svelte/store").Writable<string>} */
 export const uid = writable(null)
@@ -7,5 +8,9 @@ export const uid = writable(null)
 export const firebaseApp = writable(null)
 /** @type {import("svelte/store").Writable<number>} */
 export const currentRound = writable(0)
+/** @type {import("svelte/store").Writable<number>} */
+export const pin = derived(page, ($page) => $page.params.pin)
+/** @type {import("svelte/store").Writable<number>} */
+export const round = derived(page, ($page) => $page.params.round)
 /** @type {import("svelte/store").Writable<string>} */
 export const inputMethod = writable(INPUT_BY_KEYBOARD)

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -7,9 +7,9 @@ export const uid = writable(null)
 export const firebaseApp = writable(null)
 /** @type {import("svelte/store").Writable<number>} */
 export const currentRound = writable(0)
-/** @type {import("svelte/store").Writable<number>} */
+/** @type {import("svelte/store").Readable<number>} */
 export const pin = derived(page, ($page) => $page.params.pin)
-/** @type {import("svelte/store").Writable<number>} */
+/** @type {import("svelte/store").Readable<number>} */
 export const round = derived(page, ($page) => $page.params.round)
 /** @type {import("svelte/store").Writable<boolean>} */
 export const bidByButtons = writable(false)

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -29,15 +29,19 @@
 </script>
 
 {#if $pin}
-  <p>
-    <a href="/"> Home </a>
-    - Auction {$pin}
-    {#if $round}
-      - Round {$round}
-    {/if}
-  </p>
-  <label for="bid-method">Buttons!</label>
-  <input id="bid-method" type="checkbox" bind:checked={$bidByButtons} />
+  <div class="header-container">
+    <div class="breadcrumb">
+      <a href="/"> Home </a>
+      - Auction {$pin}
+      {#if $round}
+        - Round {$round}
+      {/if}
+    </div>
+    <div class="feature-toggle">
+      <label for="bid-method">Buttons!</label>
+      <input id="bid-method" type="checkbox" bind:checked={$bidByButtons} />
+    </div>
+  </div>
 {:else}
   <h1>Blind Auction Drafting</h1>
 {/if}
@@ -50,5 +54,13 @@
   ::global(*) {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
       Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  }
+
+  .header-container {
+    display: grid;
+    grid-template-columns: auto auto;
+  }
+  .feature-toggle {
+    justify-self: right;
   }
 </style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from "svelte"
-  import { uid, firebaseApp, pin, round } from "$lib/stores"
+  import { uid, firebaseApp, pin, round, bidByButtons } from "$lib/stores"
   import { getAuth, onAuthStateChanged } from "firebase/auth"
   import Firebase from "$lib/Firebase.svelte"
   import { logIfFalsy } from "$lib/validation"
@@ -36,6 +36,8 @@
       - Round {$round}
     {/if}
   </p>
+  <label for="bid-method">Buttons!</label>
+  <input id="bid-method" type="checkbox" bind:checked={$bidByButtons} />
 {:else}
   <h1>Blind Auction Drafting</h1>
 {/if}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,13 +1,10 @@
 <script>
   import { onMount } from "svelte"
-  import { uid, firebaseApp } from "$lib/stores"
+  import { uid, firebaseApp, pin, round } from "$lib/stores"
   import { getAuth, onAuthStateChanged } from "firebase/auth"
   import Firebase from "$lib/Firebase.svelte"
-  import { page } from "$app/stores"
   import { logIfFalsy } from "$lib/validation"
-
-  const pin = $page.params.pin
-  const round = $page.params.round
+  import { LOADING } from "$lib/constants"
 
   onMount(function () {
     onAuthStateChanged(getAuth($firebaseApp), authChangedCallback)
@@ -16,6 +13,7 @@
   /** @param {import('@firebase/auth').User} user */
   async function authChangedCallback(user) {
     if (user && !$uid) {
+      uid.set(LOADING)
       const token = await user.getIdToken()
       logIfFalsy(token, "user Firebase ID-token")
       const uidFromCookieApi = await fetch("/api/cookie", {
@@ -30,16 +28,17 @@
   }
 </script>
 
-<h1>Blind Auction Drafting</h1>
-<p>
-  <a href="/"> Home </a>
-  {#if pin}
-    - Auction {pin}
-    {#if round}
-      - Round {round}
+{#if $pin}
+  <p>
+    <a href="/"> Home </a>
+    - Auction {$pin}
+    {#if $round}
+      - Round {$round}
     {/if}
-  {/if}
-</p>
+  </p>
+{:else}
+  <h1>Blind Auction Drafting</h1>
+{/if}
 
 <slot />
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import { getAuth, signInAnonymously, signOut } from "firebase/auth"
   import { uid, firebaseApp } from "$lib/stores"
+  import { LOADING } from "$lib/constants.js"
 
   export let form
 
@@ -11,7 +12,9 @@
   }
 </script>
 
-{#if $uid}
+{#if $uid == LOADING}
+  <h3>Loading...</h3>
+{:else if $uid}
   <h3>One of you, create an auction</h3>
   {#if form?.create?.error}
     <p class="error">{form.create.error}</p>

--- a/src/routes/[pin=int]/[round=int]/+layout.svelte
+++ b/src/routes/[pin=int]/[round=int]/+layout.svelte
@@ -20,5 +20,6 @@
   .scoreboard {
     display: flex;
     justify-content: center;
+    margin: 0.5em 0;
   }
 </style>

--- a/src/routes/[pin=int]/[round=int]/+page.svelte
+++ b/src/routes/[pin=int]/[round=int]/+page.svelte
@@ -1,10 +1,9 @@
 <script>
-  import { currentRound, inputMethod } from "$lib/stores"
+  import { bidByButtons, currentRound } from "$lib/stores"
   import { enhance } from "$app/forms"
   import { page } from "$app/stores"
   import KeyboardBidItem from "./KeyboardBidItem.svelte"
   import BidButtons from "./BidButtons.svelte"
-  import { INPUT_BY_BUTTONS, INPUT_BY_KEYBOARD } from "$lib/constants"
 
   export let form
   export let data
@@ -46,14 +45,6 @@
   </div>
 </div>
 
-<div>
-  <label for="input-type">Input Type</label>
-  <select id="input-type" bind:value={$inputMethod}>
-    <option value={INPUT_BY_BUTTONS}>Buttons</option>
-    <option value={INPUT_BY_KEYBOARD}>Keyboard</option>
-  </select>
-</div>
-
 <h3>Bidding</h3>
 <form
   id="bid-form"
@@ -68,7 +59,7 @@
   <input hidden="true" value={JSON.stringify(bids)} name="bids" />
   <div class="input-container">
     {#each bids as bid, i}
-      {#if $inputMethod == INPUT_BY_BUTTONS}
+      {#if $bidByButtons}
         <BidButtons bind:bid />
       {:else}
         <KeyboardBidItem bind:bid {i} />

--- a/src/routes/[pin=int]/[round=int]/+page.svelte
+++ b/src/routes/[pin=int]/[round=int]/+page.svelte
@@ -2,6 +2,7 @@
   import { currentRound } from "$lib/stores"
   import { enhance } from "$app/forms"
   import { page } from "$app/stores"
+  import KeyboardBidItem from "./KeyboardBidItem.svelte"
 
   export let form
   export let data
@@ -58,18 +59,7 @@
   <input hidden="true" value={JSON.stringify(bids)} name="bids" />
   <div class="input-container">
     {#each bids as bid, i}
-      <div>
-        <label for="bid-{i + 1}">{i + 1}</label>
-      </div>
-      <div>
-        <input
-          id="bid-{i + 1}"
-          type="number"
-          bind:value={bid}
-          min="0"
-          max="99"
-        />
-      </div>
+      <KeyboardBidItem bind:bid {i} />
     {/each}
   </div>
   <button type="submit">Bid!</button>
@@ -104,16 +94,8 @@
     grid-template-columns: repeat(4, 1fr 3fr);
   }
 
-  .input-container > * {
-    margin-top: 8px;
-  }
-
   button {
     float: right;
-  }
-
-  label {
-    text-align: center;
   }
 
   .error {

--- a/src/routes/[pin=int]/[round=int]/+page.svelte
+++ b/src/routes/[pin=int]/[round=int]/+page.svelte
@@ -83,6 +83,10 @@
     grid-template-columns: 1fr 1fr 1fr;
   }
 
+  h3 {
+    margin: 0.25em;
+  }
+
   .previous-link {
     justify-self: left;
   }

--- a/src/routes/[pin=int]/[round=int]/+page.svelte
+++ b/src/routes/[pin=int]/[round=int]/+page.svelte
@@ -3,9 +3,12 @@
   import { enhance } from "$app/forms"
   import { page } from "$app/stores"
   import KeyboardBidItem from "./KeyboardBidItem.svelte"
+  import BidButtons from "./BidButtons.svelte"
 
   export let form
   export let data
+
+  let inputByButtons = true
 
   let bids = Array(15)
   bids.fill(null)
@@ -59,7 +62,11 @@
   <input hidden="true" value={JSON.stringify(bids)} name="bids" />
   <div class="input-container">
     {#each bids as bid, i}
-      <KeyboardBidItem bind:bid {i} />
+      {#if inputByButtons}
+        <BidButtons bind:bid />
+      {:else}
+        <KeyboardBidItem bind:bid {i} />
+      {/if}
     {/each}
   </div>
   <button type="submit">Bid!</button>

--- a/src/routes/[pin=int]/[round=int]/+page.svelte
+++ b/src/routes/[pin=int]/[round=int]/+page.svelte
@@ -91,7 +91,7 @@
 
   .input-container {
     display: grid;
-    grid-template-columns: repeat(4, 1fr 3fr);
+    grid-template-columns: repeat(4, 1fr);
   }
 
   button {

--- a/src/routes/[pin=int]/[round=int]/+page.svelte
+++ b/src/routes/[pin=int]/[round=int]/+page.svelte
@@ -58,11 +58,11 @@
 >
   <input hidden="true" value={JSON.stringify(bids)} name="bids" />
   <div class="input-container">
-    {#each bids as bid, i}
+    {#each bids as bidValue, i}
       {#if $bidByButtons}
-        <BidButtons bind:bid />
+        <BidButtons bind:bidValue {i} />
       {:else}
-        <KeyboardBidItem bind:bid {i} />
+        <KeyboardBidItem bind:bidValue {i} />
       {/if}
     {/each}
   </div>

--- a/src/routes/[pin=int]/[round=int]/+page.svelte
+++ b/src/routes/[pin=int]/[round=int]/+page.svelte
@@ -1,16 +1,13 @@
 <script>
-  import { currentRound } from "$lib/stores"
+  import { currentRound, inputMethod } from "$lib/stores"
   import { enhance } from "$app/forms"
   import { page } from "$app/stores"
   import KeyboardBidItem from "./KeyboardBidItem.svelte"
   import BidButtons from "./BidButtons.svelte"
+  import { INPUT_BY_BUTTONS, INPUT_BY_KEYBOARD } from "$lib/constants"
 
   export let form
   export let data
-
-  let inputType = keyboard
-  const buttons = "buttons"
-  const keyboard = "keyboard"
 
   let bids = Array(15)
   bids.fill(null)
@@ -51,9 +48,9 @@
 
 <div>
   <label for="input-type">Input Type</label>
-  <select id="input-type" bind:value={inputType}>
-    <option value={buttons}>Buttons</option>
-    <option value={keyboard}>Keyboard</option>
+  <select id="input-type" bind:value={$inputMethod}>
+    <option value={INPUT_BY_BUTTONS}>Buttons</option>
+    <option value={INPUT_BY_KEYBOARD}>Keyboard</option>
   </select>
 </div>
 
@@ -71,7 +68,7 @@
   <input hidden="true" value={JSON.stringify(bids)} name="bids" />
   <div class="input-container">
     {#each bids as bid, i}
-      {#if inputType == buttons}
+      {#if $inputMethod == INPUT_BY_BUTTONS}
         <BidButtons bind:bid />
       {:else}
         <KeyboardBidItem bind:bid {i} />

--- a/src/routes/[pin=int]/[round=int]/+page.svelte
+++ b/src/routes/[pin=int]/[round=int]/+page.svelte
@@ -34,12 +34,11 @@
   </div>
   <div
     class="spending-ratio"
+    class:hidden={!sumOfBids}
     class:expensive={spendingRatio > 0.8}
     class:over-budget={spendingRatio > 1}
   >
-    {#if sumOfBids}
-      {sumOfBids} / {bankSum}
-    {/if}
+    {sumOfBids} / {bankSum}
   </div>
   <div class="next-link">
     {#if $currentRound > round}
@@ -91,6 +90,9 @@
   }
   .spending-ratio {
     justify-self: center;
+  }
+  .hidden {
+    opacity: 0;
   }
   .next-link {
     justify-self: right;

--- a/src/routes/[pin=int]/[round=int]/+page.svelte
+++ b/src/routes/[pin=int]/[round=int]/+page.svelte
@@ -49,13 +49,13 @@
   </div>
 </div>
 
-<span>
+<div>
   <label for="input-type">Input Type</label>
   <select id="input-type" bind:value={inputType}>
     <option value={buttons}>Buttons</option>
     <option value={keyboard}>Keyboard</option>
   </select>
-</span>
+</div>
 
 <h3>Bidding</h3>
 <form

--- a/src/routes/[pin=int]/[round=int]/+page.svelte
+++ b/src/routes/[pin=int]/[round=int]/+page.svelte
@@ -8,7 +8,9 @@
   export let form
   export let data
 
-  let inputByButtons = true
+  let inputType = keyboard
+  const buttons = "buttons"
+  const keyboard = "keyboard"
 
   let bids = Array(15)
   bids.fill(null)
@@ -47,6 +49,14 @@
   </div>
 </div>
 
+<span>
+  <label for="input-type">Input Type</label>
+  <select id="input-type" bind:value={inputType}>
+    <option value={buttons}>Buttons</option>
+    <option value={keyboard}>Keyboard</option>
+  </select>
+</span>
+
 <h3>Bidding</h3>
 <form
   id="bid-form"
@@ -61,7 +71,7 @@
   <input hidden="true" value={JSON.stringify(bids)} name="bids" />
   <div class="input-container">
     {#each bids as bid, i}
-      {#if inputByButtons}
+      {#if inputType == buttons}
         <BidButtons bind:bid />
       {:else}
         <KeyboardBidItem bind:bid {i} />

--- a/src/routes/[pin=int]/[round=int]/BidButtons.svelte
+++ b/src/routes/[pin=int]/[round=int]/BidButtons.svelte
@@ -12,42 +12,63 @@
       {bid}
     {/if}
   </span>
-  <button class="plus-five" on:click|preventDefault={() => (bid += 5)}
-    >+5</button
-  >
-  <button class="plus-one" on:click|preventDefault={() => bid++}>+</button>
-  <button class="minus-one" on:click|preventDefault={subtract}>-</button>
+  <label for="plus-five" class="plus-five">+5</label>
+  <label for="plus-one" class="plus-one">+</label>
+  <label for="minus-one" class="minus-one">-</label>
+  <button
+    id="plus-five"
+    class="plus-five"
+    on:click|preventDefault={() => (bid += 5)}
+  />
+  <button
+    id="plus-one"
+    class="plus-one"
+    on:click|preventDefault={() => bid++}
+  />
+  <button id="minus-one" class="minus-one" on:click|preventDefault={subtract} />
 </div>
 
 <style>
   .container {
     margin: 0.3em;
     border: 1px darkgray solid;
-    border-radius: 0.5em;
     display: grid;
     grid-template-rows: repeat(4, 1.5em);
     grid-template-columns: repeat(5, 1fr);
   }
 
   button {
-    text-align: left;
     border: none;
     background: linear-gradient(to right, lightgrey, transparent);
   }
 
-  button.plus-five {
+  label {
+    text-align: center;
+  }
+
+  label.plus-five {
     font-size: small;
+    grid-area: 1 / 1 / 2 / 3;
+  }
+  label.plus-one {
+    font-size: large;
+    grid-area: 2 / 1 / 4 / 3;
+    align-self: center;
+  }
+  label.minus-one {
+    font-size: large;
+    grid-area: 4 / 1 / 5 / 3;
+  }
+  button.plus-five {
     grid-area: 1 / 1 / 2 / 6;
   }
   button.plus-one {
-    font-size: large;
     border-width: 2px 0px;
     border-style: solid;
     border-image: linear-gradient(to right, darkgray, transparent) 6;
     grid-area: 2 / 1 / 4 / 6;
   }
   button.minus-one {
-    font-size: large;
     grid-area: 4 / 1 / 5 / 6;
   }
 

--- a/src/routes/[pin=int]/[round=int]/BidButtons.svelte
+++ b/src/routes/[pin=int]/[round=int]/BidButtons.svelte
@@ -3,39 +3,45 @@
 </script>
 
 <div class="outer">
-  <div class="buttons">
-    <button class="small" on:click|preventDefault={() => (bid += 5)}>+5</button>
-    <button on:click|preventDefault={() => bid++}>+</button>
-    <button class="small" on:click|preventDefault={() => bid--}>-</button>
-  </div>
   <span class="bid">{bid}</span>
+  <button class="plus-five" on:click|preventDefault={() => (bid += 5)}
+    >+5</button
+  >
+  <button class="plus-one" on:click|preventDefault={() => bid++}>+</button>
+  <button class="minus-one" on:click|preventDefault={() => bid--}>-</button>
 </div>
 
 <style>
   .outer {
     margin: 5px;
     /* allow bid and buttons in the same space */
-  }
-
-  .buttons {
     display: grid;
-    grid-template-rows: 1fr 2fr 1fr;
+    grid-template-rows: repeat(4, 1fr);
+    grid-template-columns: 1fr;
+    grid-column-gap: 0px;
+    grid-row-gap: 0px;
   }
 
   button {
     text-align: left;
-    border-left: none;
-    border-right: none;
+    border: none;
+    opacity: 0.5;
     /* faded out */
   }
 
-  button.small {
-    border: none;
+  button.plus-five {
+    grid-area: 1 / 1 / 2 / 2;
+  }
+  button.plus-one {
+    grid-area: 2 / 1 / 4 / 2;
+  }
+  button.minus-one {
+    grid-area: 4 / 1 / 5 / 2;
   }
 
   .bid {
-    grid-row: 1 / 4;
-    font-size: larger;
+    grid-area: 1 / 1 / 5 / 2;
+    font-size: xx-large;
     /* text a little to the right */
   }
 </style>

--- a/src/routes/[pin=int]/[round=int]/BidButtons.svelte
+++ b/src/routes/[pin=int]/[round=int]/BidButtons.svelte
@@ -14,7 +14,6 @@
 <style>
   .outer {
     margin: 5px;
-    /* allow bid and buttons in the same space */
     display: grid;
     grid-template-rows: repeat(4, 1fr);
     grid-template-columns: repeat(5, 1fr);
@@ -26,7 +25,6 @@
     text-align: left;
     border: none;
     opacity: 0.5;
-    /* faded out */
   }
 
   button.plus-five {
@@ -44,6 +42,5 @@
     font-size: xx-large;
     text-align: center;
     align-self: center;
-    /* text a little to the right */
   }
 </style>

--- a/src/routes/[pin=int]/[round=int]/BidButtons.svelte
+++ b/src/routes/[pin=int]/[round=int]/BidButtons.svelte
@@ -21,9 +21,9 @@
 
 <style>
   .outer {
-    margin: 5px;
+    margin: 0.3px;
     display: grid;
-    grid-template-rows: repeat(4, 1fr);
+    grid-template-rows: repeat(4, 1.5em);
     grid-template-columns: repeat(5, 1fr);
   }
 

--- a/src/routes/[pin=int]/[round=int]/BidButtons.svelte
+++ b/src/routes/[pin=int]/[round=int]/BidButtons.svelte
@@ -6,7 +6,7 @@
   }
 </script>
 
-<div class="outer">
+<div class="container">
   <span class="bid">
     {#if bid}
       {bid}
@@ -20,7 +20,7 @@
 </div>
 
 <style>
-  .outer {
+  .container {
     margin: 0.3px;
     display: grid;
     grid-template-rows: repeat(4, 1.5em);

--- a/src/routes/[pin=int]/[round=int]/BidButtons.svelte
+++ b/src/routes/[pin=int]/[round=int]/BidButtons.svelte
@@ -2,17 +2,40 @@
   export let bid = false
 </script>
 
-<div class="input-div">
-  <button on:click|preventDefault={() => (bid += 5)}>+5</button>
-  <button on:click|preventDefault={() => bid++}>+</button>
-  <button on:click|preventDefault={() => bid--}>-</button>
+<div class="outer">
+  <div class="buttons">
+    <button class="small" on:click|preventDefault={() => (bid += 5)}>+5</button>
+    <button on:click|preventDefault={() => bid++}>+</button>
+    <button class="small" on:click|preventDefault={() => bid--}>-</button>
+  </div>
+  <span class="bid">{bid}</span>
 </div>
-<span>{bid}</span>
 
 <style>
-  .input-div {
-    margin-top: 8px;
+  .outer {
+    margin: 5px;
+    /* allow bid and buttons in the same space */
+  }
+
+  .buttons {
     display: grid;
     grid-template-rows: 1fr 2fr 1fr;
+  }
+
+  button {
+    text-align: left;
+    border-left: none;
+    border-right: none;
+    /* faded out */
+  }
+
+  button.small {
+    border: none;
+  }
+
+  .bid {
+    grid-row: 1 / 4;
+    font-size: larger;
+    /* text a little to the right */
   }
 </style>

--- a/src/routes/[pin=int]/[round=int]/BidButtons.svelte
+++ b/src/routes/[pin=int]/[round=int]/BidButtons.svelte
@@ -36,12 +36,18 @@
   }
 
   button.plus-five {
+    font-size: small;
     grid-area: 1 / 1 / 2 / 6;
   }
   button.plus-one {
+    font-size: large;
+    border-width: 2px 0px;
+    border-style: solid;
+    border-image: linear-gradient(to right, darkgray, transparent) 6;
     grid-area: 2 / 1 / 4 / 6;
   }
   button.minus-one {
+    font-size: large;
     grid-area: 4 / 1 / 5 / 6;
   }
 

--- a/src/routes/[pin=int]/[round=int]/BidButtons.svelte
+++ b/src/routes/[pin=int]/[round=int]/BidButtons.svelte
@@ -1,0 +1,18 @@
+<script>
+  export let bid = false
+</script>
+
+<div class="input-div">
+  <button on:click|preventDefault={() => (bid += 5)}>+5</button>
+  <button on:click|preventDefault={() => bid++}>+</button>
+  <button on:click|preventDefault={() => bid--}>-</button>
+</div>
+<span>{bid}</span>
+
+<style>
+  .input-div {
+    margin-top: 8px;
+    display: grid;
+    grid-template-rows: 1fr 2fr 1fr;
+  }
+</style>

--- a/src/routes/[pin=int]/[round=int]/BidButtons.svelte
+++ b/src/routes/[pin=int]/[round=int]/BidButtons.svelte
@@ -17,8 +17,6 @@
     display: grid;
     grid-template-rows: repeat(4, 1fr);
     grid-template-columns: repeat(5, 1fr);
-    grid-column-gap: 0px;
-    grid-row-gap: 0px;
   }
 
   button {

--- a/src/routes/[pin=int]/[round=int]/BidButtons.svelte
+++ b/src/routes/[pin=int]/[round=int]/BidButtons.svelte
@@ -17,7 +17,7 @@
     /* allow bid and buttons in the same space */
     display: grid;
     grid-template-rows: repeat(4, 1fr);
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(5, 1fr);
     grid-column-gap: 0px;
     grid-row-gap: 0px;
   }
@@ -30,18 +30,20 @@
   }
 
   button.plus-five {
-    grid-area: 1 / 1 / 2 / 2;
+    grid-area: 1 / 1 / 2 / 6;
   }
   button.plus-one {
-    grid-area: 2 / 1 / 4 / 2;
+    grid-area: 2 / 1 / 4 / 6;
   }
   button.minus-one {
-    grid-area: 4 / 1 / 5 / 2;
+    grid-area: 4 / 1 / 5 / 6;
   }
 
   .bid {
-    grid-area: 1 / 1 / 5 / 2;
+    grid-area: 1 / 2 / 5 / 6;
     font-size: xx-large;
+    text-align: center;
+    align-self: center;
     /* text a little to the right */
   }
 </style>

--- a/src/routes/[pin=int]/[round=int]/BidButtons.svelte
+++ b/src/routes/[pin=int]/[round=int]/BidButtons.svelte
@@ -1,31 +1,36 @@
 <script>
-  export let bid = false
+  export let bidValue = false
+  export let i
 
   function subtract() {
-    if (bid > 0) bid--
+    if (bidValue > 0) bidValue--
   }
 </script>
 
 <div class="container">
   <span class="bid">
-    {#if bid != null}
-      {bid}
+    {#if bidValue != null}
+      {bidValue}
     {/if}
   </span>
-  <label for="plus-five" class="plus-five">+5</label>
-  <label for="plus-one" class="plus-one">+</label>
-  <label for="minus-one" class="minus-one">-</label>
+  <label for="plus-five-{i}" class="plus-five">+5</label>
+  <label for="plus-one-{i}" class="plus-one">+</label>
+  <label for="minus-one-{i}" class="minus-one">-</label>
   <button
-    id="plus-five"
+    id="plus-five-{i}"
     class="plus-five"
-    on:click|preventDefault={() => (bid += 5)}
+    on:click|preventDefault={() => (bidValue += 5)}
   />
   <button
-    id="plus-one"
+    id="plus-one-{i}"
     class="plus-one"
-    on:click|preventDefault={() => bid++}
+    on:click|preventDefault={() => bidValue++}
   />
-  <button id="minus-one" class="minus-one" on:click|preventDefault={subtract} />
+  <button
+    id="minus-one-{i}"
+    class="minus-one"
+    on:click|preventDefault={subtract}
+  />
 </div>
 
 <style>

--- a/src/routes/[pin=int]/[round=int]/BidButtons.svelte
+++ b/src/routes/[pin=int]/[round=int]/BidButtons.svelte
@@ -8,7 +8,7 @@
 
 <div class="container">
   <span class="bid">
-    {#if bid}
+    {#if bid != null}
       {bid}
     {/if}
   </span>
@@ -21,7 +21,9 @@
 
 <style>
   .container {
-    margin: 0.3px;
+    margin: 0.3em;
+    border: 1px darkgray solid;
+    border-radius: 0.5em;
     display: grid;
     grid-template-rows: repeat(4, 1.5em);
     grid-template-columns: repeat(5, 1fr);
@@ -30,7 +32,7 @@
   button {
     text-align: left;
     border: none;
-    opacity: 0.5;
+    background: linear-gradient(to right, lightgrey, transparent);
   }
 
   button.plus-five {

--- a/src/routes/[pin=int]/[round=int]/BidButtons.svelte
+++ b/src/routes/[pin=int]/[round=int]/BidButtons.svelte
@@ -2,8 +2,20 @@
   export let bidValue = false
   export let i
 
-  function subtract() {
-    if (bidValue > 0) bidValue--
+  function plusFive(iValue) {
+    if (iValue == i) {
+      bidValue += 5
+    }
+  }
+  function plusOne(iValue) {
+    if (iValue == i) {
+      bidValue++
+    }
+  }
+  function minusOne(iValue) {
+    if (iValue == i && bidValue > 0) {
+      bidValue--
+    }
   }
 </script>
 
@@ -19,17 +31,17 @@
   <button
     id="plus-five-{i}"
     class="plus-five"
-    on:click|preventDefault={() => (bidValue += 5)}
+    on:click|preventDefault={() => plusFive(i)}
   />
   <button
     id="plus-one-{i}"
     class="plus-one"
-    on:click|preventDefault={() => bidValue++}
+    on:click|preventDefault={() => plusOne(i)}
   />
   <button
     id="minus-one-{i}"
     class="minus-one"
-    on:click|preventDefault={subtract}
+    on:click|preventDefault={minusOne(i)}
   />
 </div>
 

--- a/src/routes/[pin=int]/[round=int]/BidButtons.svelte
+++ b/src/routes/[pin=int]/[round=int]/BidButtons.svelte
@@ -31,12 +31,12 @@
   <button
     id="plus-five-{i}"
     class="plus-five"
-    on:click|preventDefault={() => plusFive(i)}
+    on:click|preventDefault={plusFive(i)}
   />
   <button
     id="plus-one-{i}"
     class="plus-one"
-    on:click|preventDefault={() => plusOne(i)}
+    on:click|preventDefault={plusOne(i)}
   />
   <button
     id="minus-one-{i}"

--- a/src/routes/[pin=int]/[round=int]/BidButtons.svelte
+++ b/src/routes/[pin=int]/[round=int]/BidButtons.svelte
@@ -1,14 +1,22 @@
 <script>
   export let bid = false
+
+  function subtract() {
+    if (bid > 0) bid--
+  }
 </script>
 
 <div class="outer">
-  <span class="bid">{bid}</span>
+  <span class="bid">
+    {#if bid}
+      {bid}
+    {/if}
+  </span>
   <button class="plus-five" on:click|preventDefault={() => (bid += 5)}
     >+5</button
   >
   <button class="plus-one" on:click|preventDefault={() => bid++}>+</button>
-  <button class="minus-one" on:click|preventDefault={() => bid--}>-</button>
+  <button class="minus-one" on:click|preventDefault={subtract}>-</button>
 </div>
 
 <style>

--- a/src/routes/[pin=int]/[round=int]/KeyboardBidItem.svelte
+++ b/src/routes/[pin=int]/[round=int]/KeyboardBidItem.svelte
@@ -1,0 +1,21 @@
+<script>
+  export let bid = false
+  export let i = false
+</script>
+
+<div class="input-div">
+  <label for="bid-{i + 1}">{i + 1}</label>
+</div>
+<div class="input-div">
+  <input id="bid-{i + 1}" type="number" bind:value={bid} min="0" max="99" />
+</div>
+
+<style>
+  .input-div {
+    margin-top: 8px;
+  }
+
+  label {
+    text-align: center;
+  }
+</style>

--- a/src/routes/[pin=int]/[round=int]/KeyboardBidItem.svelte
+++ b/src/routes/[pin=int]/[round=int]/KeyboardBidItem.svelte
@@ -3,19 +3,23 @@
   export let i = false
 </script>
 
-<div class="input-div">
-  <label for="bid-{i + 1}">{i + 1}</label>
-</div>
-<div class="input-div">
-  <input id="bid-{i + 1}" type="number" bind:value={bid} min="0" max="99" />
+<div class="input-container">
+  <div>
+    <label for="bid-{i + 1}">{i + 1}</label>
+  </div>
+  <div>
+    <input id="bid-{i + 1}" type="number" bind:value={bid} min="0" max="99" />
+  </div>
 </div>
 
 <style>
-  .input-div {
-    margin-top: 8px;
-  }
-
   label {
     text-align: center;
+  }
+
+  .input-container {
+    margin: 5px;
+    display: grid;
+    grid-template-columns: 1fr 3fr;
   }
 </style>

--- a/src/routes/[pin=int]/[round=int]/KeyboardBidItem.svelte
+++ b/src/routes/[pin=int]/[round=int]/KeyboardBidItem.svelte
@@ -1,5 +1,5 @@
 <script>
-  export let bid = false
+  export let bidValue = false
   export let i = false
 </script>
 
@@ -8,7 +8,13 @@
     <label for="bid-{i + 1}">{i + 1}</label>
   </div>
   <div>
-    <input id="bid-{i + 1}" type="number" bind:value={bid} min="0" max="99" />
+    <input
+      id="bid-{i + 1}"
+      type="number"
+      bind:value={bidValue}
+      min="0"
+      max="99"
+    />
   </div>
 </div>
 


### PR DESCRIPTION
This change allows the bidder to set their bids using a set of buttons, +5, +1 and -1, one set for each card in a pack. 
- Toggle to change between buttons and keyboard input methods

Also in this request:
- Loading state when logging in
- Use stores for pin and round derived from app stores instead of reading from indirectly URL
- Changing how the spending ratio is hidden when empty