### PR TITLE
Rotate bid options every round

### DIFF
--- a/src/routes/[auction_number=int]/[round=int]/+page.server.js
+++ b/src/routes/[auction_number=int]/[round=int]/+page.server.js
@@ -140,7 +140,9 @@ export const actions = {
       )
       return fail(500, { success: false, error: "Database error" })
     }
-    const optionsForThisUser = BID_OPTIONS.get(auctionSize)?.at(seat)
+    const round = parseInt(event.params.round)
+    const rotatedSeat = (seat + round) % auctionSize
+    const optionsForThisUser = BID_OPTIONS.get(auctionSize)?.at(rotatedSeat)
     const bidsConvertedToOptions = bids.map((bid) => {
       return optionsForThisUser?.at(bid) || 0
     })
@@ -148,7 +150,6 @@ export const actions = {
     if (pointsRemaining < sumOfBids) {
       return fail(400, { success: false, error: "Insufficient funds" })
     }
-    const round = parseInt(event.params.round)
     const insertBids = await db
       .prepare(
         `INSERT INTO bids (user_id, round, bid_values) 

--- a/src/routes/[auction_number=int]/[round=int]/+page.svelte
+++ b/src/routes/[auction_number=int]/[round=int]/+page.svelte
@@ -27,7 +27,8 @@
   let results = $derived(data.results)
   let remainingPoints = $derived(data.points.at(data.seat) || -1)
   let auctionSize = $derived(data.points.length)
-  let options = $derived(BID_OPTIONS.get(auctionSize)?.at(data.seat) || [])
+  let rotatedSeat = $derived((data.seat + round) % auctionSize)
+  let options = $derived(BID_OPTIONS.get(auctionSize)?.at(rotatedSeat) || [])
   let sumOfBids = $derived(
     bids.reduce((sum, value) => sum + (options.at(value) || 0), 0),
   )


### PR DESCRIPTION
The bid options now rotate between users every round. This minimises any advantage a bidder could get from having the lowest or highest bid option among all bidders. 